### PR TITLE
Change InitState to json type.

### DIFF
--- a/nianioPatternWithNl.js
+++ b/nianioPatternWithNl.js
@@ -96,8 +96,8 @@ function NianioStartWithNl({ ptd, nianioFunc, initState, workerFactories, nianio
         queue = [];
         isScheduled = false;
 
-        const initStateImm = initState();
-        _ = nl.imm_to_json(initStateImm, ptd['state'], ptd); // walidacja
+        const initStateImm = nl.json_to_imm(initState, ptd['state'], ptd); //initState ma być jsonem, a nie wskaźnikiem do Nianio
+        // _ = nl.imm_to_json(initStateImm, ptd['state'], ptd); // walidacja odbywa się już wyżej w momencie konwersji jsona do typu imm
         state = initStateImm;
 
         initWorkers();


### PR DESCRIPTION
Chcemy żeby w wersji z podłączonym NianioLangiem stan inicjalny nie był wskaźnikiem do Nianio (bo tam nie możemy podać żadnych parametrów), a jsonem, który można sparametryzować wartościami początkowymi. W sumie to jest jedna linia zmiany bo funckja jnon_to_imm już istnieje.